### PR TITLE
Fix LED bar utility 

### DIFF
--- a/src/lib/ServoOutput/devServoOutput.cpp
+++ b/src/lib/ServoOutput/devServoOutput.cpp
@@ -63,15 +63,22 @@ static void servoWrite(uint8_t ch, uint16_t us)
 
 static void servosFailsafe()
 {
-    constexpr unsigned SERVO_FAILSAFE_MIN = 988U;
+
+    // Lower SERVO_FAILSAFE_MIN to 900us, 988us resulted in LED still being on at 1% brightness
+    // constexpr unsigned SERVO_FAILSAFE_MIN = 988U;
+    constexpr unsigned SERVO_FAILSAFE_MIN = 900U;
+
     for (unsigned ch = 0; ch < servoMgr->getOutputCnt(); ++ch)
     {
         const rx_config_pwm_t *chConfig = config.GetPwmChannel(ch);
         // Note: Failsafe values do not respect the inverted flag, failsafes are absolute
-        uint16_t us = chConfig->val.failsafe + SERVO_FAILSAFE_MIN;
+        // uint16_t us = chConfig->val.failsafe + SERVO_FAILSAFE_MIN;
         // Always write the failsafe position even if the servo never has been started,
         // so all the servos go to their expected position
-        servoWrite(ch, us);
+        // servoWrite(ch, us);
+        
+        // Forcing failsafe mode for any switch position to be all lights OFF
+        servoWrite(ch, SERVO_FAILSAFE_MIN);
     }
 }
 
@@ -100,7 +107,15 @@ static int servosUpdate(unsigned long now)
             {
                 us = 3000U - us;
             }
-            servoWrite(ch, us);
+            
+            // Force true "OFF" mode for Overt LEDs and IR LEDs
+            if(us < 1050U){
+                servoWrite(ch,900U);
+            }
+            else
+            {
+                servoWrite(ch, us);
+            }
         } /* for each servo */
     }     /* if newChannelsAvailable */
 

--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -5,33 +5,7 @@ extra_configs =
 	# keep common first
 	targets/common.ini
 	# defined one by one to maintain the order
-	targets/ELRS_2400.ini
-	targets/axis_2400.ini
-	targets/frsky.ini
-	targets/emax_900.ini
-	targets/emax_2400.ini
 	targets/happymodel_900.ini
-	targets/happymodel_2400.ini
-	targets/betafpv_900.ini
-	targets/betafpv_2400.ini
-	targets/imrc.ini
-	targets/namimnorc_900.ini
-	targets/namimnorc_2400.ini
-	targets/neutronrc_900.ini
-	targets/siyi.ini
-	targets/HGLRC_900.ini
-	targets/HGLRC_2400.ini
-	targets/quadkopters_2400.ini
-	targets/diy_900.ini
-	targets/diy_2400.ini
-	targets/diy_ble_joystick.ini
-	targets/MATEK_2400.ini
-	targets/iFlight_900.ini
-	targets/iFlight_2400.ini
-	targets/vantac_2400.ini
-	targets/Jumper_2400.ini
-	targets/radiomaster_2400.ini
-	targets/foxeer_2400.ini
 	targets/unified.ini
 
 # ------------------------- TARGET ENV DEFINITIONS -----------------

--- a/src/targets/unified.ini
+++ b/src/targets/unified.ini
@@ -130,7 +130,9 @@ build_src_filter = ${env_common_esp32rx.build_src_filter} -<tx_*.cpp>
 extends = env:Unified_ESP32_900_RX_via_UART
 upload_protocol = custom
 upload_speed = 420000
-upload_command = ${env_common_esp82xx.bf_upload_command}
+; Custom upload command (bf_upload_command) not defined in env_common_esp82xx (in common.ini)
+; Commented below line out to prevent errors during build since we aren't using betaflight
+; upload_command = ${env_common_esp82xx.bf_upload_command}
 
 [env:Unified_ESP32_900_RX_via_WIFI]
 extends = env:Unified_ESP32_900_RX_via_UART


### PR DESCRIPTION
Fixed failsafe issue where LED bar was not turning completely off when transmitter either lost connection or was powered off. Failsafe mode for all switch positions now turn all LEDs (Overt and IR) to "OFF" state. 

Fixed issue where "OFF" state for LED bar was not actually off and Overt LEDs were still on at 1% brightness level. "OFF" state now means all LEDs (Overt and IR) are truly off.